### PR TITLE
media: Add flags, channelMask, and UID to audio session callbacks

### DIFF
--- a/core/jni/android_media_AudioSystem.cpp
+++ b/core/jni/android_media_AudioSystem.cpp
@@ -393,7 +393,8 @@ android_media_AudioSystem_dyn_policy_callback(int event, String8 regId, int val)
 
 static void
 android_media_AudioSystem_effect_session_callback(int event, audio_stream_type_t stream,
-        audio_unique_id_t sessionId, bool added)
+        audio_unique_id_t sessionId, audio_output_flags_t flags,
+        audio_channel_mask_t channelMask, uid_t uid, bool added)
 {
     JNIEnv *env = AndroidRuntime::getJNIEnv();
     if (env == NULL) {
@@ -403,7 +404,7 @@ android_media_AudioSystem_effect_session_callback(int event, audio_stream_type_t
     jclass clazz = env->FindClass(kClassPathName);
 
     env->CallStaticVoidMethod(clazz, gEffectSessionEventHandlerMethods.postEffectSessionEventFromNative,
-            event, stream, sessionId, added);
+            event, stream, sessionId, flags, channelMask, uid, added);
 
     env->DeleteLocalRef(clazz);
 
@@ -1799,7 +1800,7 @@ int register_android_media_AudioSystem(JNIEnv *env)
 
     gEffectSessionEventHandlerMethods.postEffectSessionEventFromNative =
             GetStaticMethodIDOrDie(env, env->FindClass(kClassPathName),
-                    "effectSessionCallbackFromNative", "(IIIZ)V");
+                    "effectSessionCallbackFromNative", "(IIIIIIZ)V");
 
     jclass audioMixClass = FindClassOrDie(env, "android/media/audiopolicy/AudioMix");
     gAudioMixClass = MakeGlobalRefOrDie(env, audioMixClass);

--- a/media/java/android/media/AudioSystem.java
+++ b/media/java/android/media/AudioSystem.java
@@ -274,7 +274,7 @@ public class AudioSystem
      */
     public interface EffectSessionCallback
     {
-        void onSessionAdded(int stream, int sessionId);
+        void onSessionAdded(int stream, int sessionId, int flags, int channelMask, int uid);
 
         void onSessionRemoved(int stream, int sessionId);
     }
@@ -292,7 +292,8 @@ public class AudioSystem
         }
     }
 
-    private static void effectSessionCallbackFromNative(int event, int stream, int sessionId, boolean added)
+    private static void effectSessionCallbackFromNative(int event, int stream, int sessionId,
+            int flags, int channelMask, int uid, boolean added)
     {
         EffectSessionCallback cb = null;
         synchronized (AudioSystem.class) {
@@ -304,7 +305,7 @@ public class AudioSystem
             switch(event) {
                 case AUDIO_OUTPUT_SESSION_EFFECTS_UPDATE:
                     if (added) {
-                        cb.onSessionAdded(stream, sessionId);
+                        cb.onSessionAdded(stream, sessionId, flags, channelMask, uid);
                     } else {
                         cb.onSessionRemoved(stream, sessionId);
                     }


### PR DESCRIPTION
 * This is to allow us to implement more sophisticated logic in
   the application on when to apply effects to a stream.

Change-Id: I2931daa1546591e18d98acc91775c1fdafa3d453