### PR TITLE
SysUI: Animate notificaiton panel back into view

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/keyguard/KeyguardViewMediator.java
+++ b/packages/SystemUI/src/com/android/systemui/keyguard/KeyguardViewMediator.java
@@ -1297,7 +1297,10 @@ public class KeyguardViewMediator extends SystemUI {
         mHandler.post(new Runnable() {
             @Override
             public void run() {
+                // Get the keyguard into the correct state by calling mStatusBar.showKeyguard()
                 mStatusBar.showKeyguard();
+                // Now have the notification panel slid back into view
+                mStatusBar.slideNotificationPanelIn();
             }
         });
     }

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/NotificationPanelView.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/NotificationPanelView.java
@@ -106,6 +106,8 @@ public class NotificationPanelView extends PanelView implements
 
     private static final Rect mDummyDirtyRect = new Rect(0, 0, 1, 1);
 
+    private static final long SLIDE_PANEL_IN_ANIMATION_DURATION = 300;
+
     public static final long DOZE_ANIMATION_DURATION = 700;
 
 
@@ -313,6 +315,7 @@ public class NotificationPanelView extends PanelView implements
             // being swiped away
             mKeyguardStatusView.setTranslationX(mNotificationStackScroller.getTranslationX());
             mKeyguardStatusView.setAlpha(mNotificationStackScroller.getAlpha());
+            mKeyguardStatusBar.setAlpha(mNotificationStackScroller.getAlpha());
             return false;
         }
 
@@ -1848,7 +1851,6 @@ public class NotificationPanelView extends PanelView implements
         mNotificationStackScroller.setShadeExpanded(!isFullyCollapsed());
         if (mShowingExternalKeyguard && expandedHeight >= getMaxPanelHeight()) {
             mStatusBar.unfocusKeyguardExternalView();
-            mLiveLockscreenController.onLiveLockScreenFocusChanged(false /* hasFocus */);
             mShowingExternalKeyguard = false;
         }
         if (DEBUG) {
@@ -2814,7 +2816,62 @@ public class NotificationPanelView extends PanelView implements
         return !tasks.isEmpty() && pkgName.equals(tasks.get(0).topActivity.getPackageName());
     }
 
-    public void slideLockScreenOut() {
-        mSwipeCallback.onChildDismissed(this);
+    private class SlideInAnimationListener implements ValueAnimator.AnimatorUpdateListener,
+            ValueAnimator.AnimatorListener {
+        @Override
+        public void onAnimationStart(Animator animator) {}
+
+        @Override
+        public void onAnimationEnd(Animator animator) {
+            animationFinished(animator);
+        }
+
+        @Override
+        public void onAnimationCancel(Animator animator) {
+            animationFinished(animator);
+        }
+
+        @Override
+        public void onAnimationRepeat(Animator animator) {}
+
+        @Override
+        public void onAnimationUpdate(ValueAnimator valueAnimator) {
+            float translationX = (Float) valueAnimator.getAnimatedValue();
+            float alpha = valueAnimator.getAnimatedFraction();
+
+            mNotificationStackScroller.setTranslationX(translationX);
+            mNotificationStackScroller.setAlpha(alpha);
+
+            mKeyguardStatusView.setTranslationX(translationX);
+            mKeyguardStatusView.setAlpha(alpha);
+
+            mKeyguardStatusBar.setAlpha(alpha);
+            mLiveLockscreenController.getLiveLockScreenView()
+                    .onLockscreenSlideOffsetChanged(alpha);
+        }
+
+        private void animationFinished(Animator animator) {
+            mLiveLockscreenController.onLiveLockScreenFocusChanged(false);
+        }
+    }
+
+    private SlideInAnimationListener mSlideInAnimationListener = new SlideInAnimationListener();
+
+    public void slideLockScreenIn() {
+        mNotificationStackScroller.setVisibility(View.VISIBLE);
+        mNotificationStackScroller.setAlpha(0f);
+        mNotificationStackScroller.setTranslationX(-mNotificationStackScroller.getWidth());
+        mKeyguardStatusView.setVisibility(View.VISIBLE);
+        mKeyguardStatusView.setAlpha(0f);
+        mKeyguardStatusView.setTranslationX(mNotificationStackScroller.getTranslationX());
+        mKeyguardStatusBar.setAlpha(0f);
+
+        ValueAnimator animator = ValueAnimator.ofFloat(
+                mNotificationStackScroller.getTranslationX(),
+                0f);
+        animator.setDuration(SLIDE_PANEL_IN_ANIMATION_DURATION);
+        animator.addUpdateListener(mSlideInAnimationListener);
+        animator.addListener(mSlideInAnimationListener);
+        animator.start();
     }
 }

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/PhoneStatusBar.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/PhoneStatusBar.java
@@ -5375,6 +5375,10 @@ public class PhoneStatusBar extends BaseStatusBar implements DemoMode,
         return mLiveLockScreenController.isShowingLiveLockScreenView();
     }
 
+    public void slideNotificationPanelIn() {
+        mNotificationPanel.slideLockScreenIn();
+    }
+
     private final class ShadeUpdates {
         private final ArraySet<String> mVisibleNotifications = new ArraySet<String>();
         private final ArraySet<String> mNewVisibleNotifications = new ArraySet<String>();

--- a/packages/SystemUI/src/com/android/systemui/statusbar/policy/LiveLockScreenController.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/policy/LiveLockScreenController.java
@@ -229,18 +229,16 @@ public class LiveLockScreenController {
     }
 
     public void onLiveLockScreenFocusChanged(boolean hasFocus) {
-        if (hasFocus != mLlsHasFocus) {
-            mLlsHasFocus = hasFocus;
-            if (mLiveLockScreenView != null) {
-                // make sure the LLS knows where the notification panel is
-                mLiveLockScreenView.onLockscreenSlideOffsetChanged(hasFocus ? 0f : 1f);
-            }
-            // don't log focus changes when screen is not interactive
-            if (mPowerManager.isInteractive()) {
-                EventLog.writeEvent(EventLogTags.SYSUI_LLS_NOTIFICATION_PANEL_SHOWN,
-                        hasFocus ? 0 : 1);
-            }
+        if (mLiveLockScreenView != null) {
+            // make sure the LLS knows where the notification panel is
+            mLiveLockScreenView.onLockscreenSlideOffsetChanged(hasFocus ? 0f : 1f);
         }
+        // don't log focus changes when screen is not interactive
+        if (hasFocus != mLlsHasFocus && mPowerManager.isInteractive()) {
+            EventLog.writeEvent(EventLogTags.SYSUI_LLS_NOTIFICATION_PANEL_SHOWN,
+                    hasFocus ? 0 : 1);
+        }
+        mLlsHasFocus = hasFocus;
     }
 
     public void onKeyguardDismissed() {


### PR DESCRIPTION
Add an animation for when the user has swiped the left edge to bring
the notificaiton panel back into view from the left side.

Change-Id: Ie2ab3482a39d2d9c7b93a853f6ebae43a174e2c0
TICKET: CYNGNOS-2549